### PR TITLE
feat: support manifestless updates using Git tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ cryptographic hashes and swaps files atomically with rollback support.
 4. Upload the manifest and files as release assets.  The updater can then
    fetch the latest release or a specific tag when `CONFIG['tag']` is set.
 
+   If you prefer to avoid attaching a manifest, omit `manifest.json` from
+   the release and the updater will derive file paths from the Git tree at
+   the tag.  Each file is verified against its Git blob SHA before being
+   staged.  Set `CONFIG['paths']` to a list of directories or files to
+   restrict which parts of the repository are updated.
+
 ## Testing
 
 The repository includes unit tests that exercise hash verification,

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -4,7 +4,7 @@ import hashlib
 import binascii
 import pytest
 
-from ota_updater import OTAUpdater, sha256_file, crc32_file, OTAError
+from ota_updater import OTAUpdater, sha256_file, crc32_file, OTAError, sha1_git_blob_stream
 
 
 def test_sha256_and_crc32():
@@ -29,3 +29,14 @@ def test_verify_file():
     with pytest.raises(OTAError):
         upd._verify_file(name, "0" * 64, size)
     os.remove(name)
+
+
+def test_git_blob_sha1_stream():
+    data = b"blob data"
+    size = len(data)
+
+    def reader(n):
+        yield data
+
+    expect = hashlib.sha1(b"blob " + str(size).encode() + b"\x00" + data).hexdigest()
+    assert sha1_git_blob_stream(size, reader) == expect


### PR DESCRIPTION
## Summary
- add Git blob SHA1 streaming helper and GitHub tree helpers
- allow `update()` to derive file list from repository tree when `manifest.json` is absent
- document optional manifestless mode

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba294c307c8333ab8276f232028daf