### PR TITLE
Add startup rollback checks and manifest signing

### DIFF
--- a/tests/test_manifest_sig.py
+++ b/tests/test_manifest_sig.py
@@ -1,0 +1,25 @@
+import json
+import hmac
+import hashlib
+import pytest
+from ota_updater import OTAUpdater, OTAError
+
+
+def _sign(manifest, key):
+    data = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    sig = hmac.new(key.encode(), data, hashlib.sha256).hexdigest()
+    manifest['signature'] = sig
+    return manifest
+
+
+def test_manifest_signature_ok():
+    m = _sign({'version': '1', 'files': []}, 'secret')
+    upd = OTAUpdater({'manifest_key': 'secret'}, log=False)
+    upd._verify_manifest_signature(m)
+
+
+def test_manifest_signature_bad():
+    m = {'version': '1', 'files': [], 'signature': 'bad'}
+    upd = OTAUpdater({'manifest_key': 'secret'}, log=False)
+    with pytest.raises(OTAError):
+        upd._verify_manifest_signature(m)

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,0 +1,26 @@
+import os
+from ota_updater import OTAUpdater
+
+
+def test_startup_rollback(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    os.makedirs('.ota_backup', exist_ok=True)
+    os.makedirs('.ota_stage', exist_ok=True)
+    with open('.ota_backup/app.txt', 'w') as f:
+        f.write('old')
+    with open('.ota_stage/app.txt', 'w') as f:
+        f.write('new')
+    OTAUpdater({}, log=False)
+    assert (tmp_path / 'app.txt').read_text() == 'old'
+    assert os.listdir('.ota_backup') == []
+    assert os.listdir('.ota_stage') == []
+
+
+def test_startup_stage_cleanup(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    os.makedirs('.ota_stage', exist_ok=True)
+    with open('.ota_stage/app.txt', 'w') as f:
+        f.write('new')
+    os.makedirs('.ota_backup', exist_ok=True)
+    OTAUpdater({}, log=False)
+    assert os.listdir('.ota_stage') == []

--- a/tests/test_startup_client.py
+++ b/tests/test_startup_client.py
@@ -1,0 +1,16 @@
+import os
+from ota_client import OtaClient
+
+
+def test_client_startup_rollback(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    os.makedirs('.ota_backup', exist_ok=True)
+    os.makedirs('.ota_stage', exist_ok=True)
+    with open('.ota_backup/app.txt', 'w') as f:
+        f.write('old')
+    with open('.ota_stage/app.txt', 'w') as f:
+        f.write('new')
+    OtaClient({'owner': 'o', 'repo': 'r'})
+    assert (tmp_path / 'app.txt').read_text() == 'old'
+    assert os.listdir('.ota_backup') == []
+    assert os.listdir('.ota_stage') == []


### PR DESCRIPTION
## Summary
- Roll back automatically from leftover backups and clean staging on boot
- Verify manifest authenticity via HMAC signature and enable signing in manifest generator
- Test startup recovery and manifest signature verification

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba4fdd72d88333b64219b5e44c4e76