### PR TITLE
Handle debug tracebacks on main failures

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 """Example entry point for the ``OtaClient``."""
 
 import json
+import traceback
 from ota_client import OtaClient
 
 
@@ -10,12 +11,15 @@ def load_config():
 
 
 def main():
-    cfg = load_config()
-    ota = OtaClient(cfg)
     try:
+        cfg = load_config()
+        ota = OtaClient(cfg)
         ota.connect()
         ota.update_if_available()
     except Exception as exc:
+        cfg_local = locals().get("cfg", {})
+        if cfg_local.get("debug"):
+            traceback.print_exc()
         print("OTA update failed:", exc)
 
 


### PR DESCRIPTION
## Summary
- Wrap configuration load and update flow in a single `try/except`
- Print a full traceback when `debug` is enabled in configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bab3f53ea08333b7becc73a7e521e3