### PR TITLE
Handle non-200 responses in OTA JSON fetch

### DIFF
--- a/tests/test_get_json.py
+++ b/tests/test_get_json.py
@@ -1,0 +1,20 @@
+import pytest
+from ota_client import OtaClient, OTAError
+
+
+class Resp:
+    def __init__(self, status_code=404, body="Not Found"):
+        self.status_code = status_code
+        self.text = body
+    def close(self):
+        pass
+
+
+def test_get_json_http_error():
+    client = OtaClient({"owner": "o", "repo": "r"})
+    client._get = lambda url, raw=False: Resp()
+    with pytest.raises(OTAError) as excinfo:
+        client._get_json("http://example.com")
+    msg = str(excinfo.value)
+    assert "404" in msg
+    assert "Not Found" in msg


### PR DESCRIPTION
## Summary
- raise OTAError when HTTP status is not 200 including response snippet
- test _get_json for HTTP error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bab44178508333ba4f86afc7f1d7e9