### PR TITLE
Add customizable User-Agent header for OTA client

### DIFF
--- a/ota_client.py
+++ b/ota_client.py
@@ -145,6 +145,8 @@ class OtaClient:
         token = self.cfg.get("token")
         if token:
             h["Authorization"] = "token {}".format(token)
+        # Identify the client to the API; allow customization via config
+        h["User-Agent"] = self.cfg.get("user_agent", "ota-updater")
         return h
 
     def _get(self, url: str, raw: bool = False):  # pragma: no cover - overridden in tests


### PR DESCRIPTION
## Summary
- add `User-Agent` HTTP header in OTA client requests with optional configuration override

## Testing
- `pytest`
- `python - <<'PY'
import json as jsonmod
import main
import ota_client
import urllib.request

class SimpleResp:
    def __init__(self, resp):
        self._resp = resp
        self.status_code = resp.getcode()
    def json(self):
        return jsonmod.loads(self._resp.read().decode())
    def read(self, n=-1):
        return self._resp.read(n)
    def close(self):
        self._resp.close()
    @property
    def text(self):
        data = self._resp.read()
        try:
            return data.decode()
        except Exception:
            return ""
    @property
    def content(self):
        return self._resp.read()

class SimpleRequests:
    def get(self, url, headers=None, stream=False):
        req = urllib.request.Request(url, headers=headers or {})
        resp = urllib.request.urlopen(req)
        return SimpleResp(resp)

ota_client.requests = SimpleRequests()
cfg={
"owner":"octocat","repo":"Hello-World",
"ssid":"WIFI","password":"SECRET",
"channel":"developer","branch":"master",
"token": None,"allow":["README"],"ignore":[],
"chunk":512,"connect_timeout_sec":20,"http_timeout_sec":20,
"retries":3,"backoff_sec":3,"debug":True,
"user_agent":"ota-updater-test"}
with open('ota_config.json','w') as f: jsonmod.dump(cfg,f)
main.main()
PY` *(403 - Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bab545406883339b3fd2818460f33d