### PR TITLE
feat: support configurable HTTP timeouts

### DIFF
--- a/ota_client.py
+++ b/ota_client.py
@@ -154,7 +154,19 @@ class OtaClient:
         if raw:
             headers["Accept"] = "application/octet-stream"
         self._debug("GET", url)
-        r = requests.get(url, headers=headers, stream=raw)
+        connect_timeout = self.cfg.get("connect_timeout_sec")
+        read_timeout = self.cfg.get("http_timeout_sec")
+        timeout = None
+        if connect_timeout is not None and read_timeout is not None:
+            timeout = (connect_timeout, read_timeout)
+        elif connect_timeout is not None:
+            timeout = connect_timeout
+        elif read_timeout is not None:
+            timeout = read_timeout
+        if timeout is not None:
+            r = requests.get(url, headers=headers, stream=raw, timeout=timeout)
+        else:
+            r = requests.get(url, headers=headers, stream=raw)
         self._debug("->", getattr(r, "status_code", "?"))
         return r
 

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,0 +1,33 @@
+from ota_client import OtaClient
+
+
+class DummyRequests:
+    def __init__(self):
+        self.timeout = None
+
+    def get(self, url, headers=None, stream=None, timeout=None):
+        self.timeout = timeout
+
+        class Resp:
+            status_code = 200
+
+            def close(self):
+                pass
+
+        return Resp()
+
+
+def test_get_uses_configured_timeouts(monkeypatch):
+    dummy = DummyRequests()
+    monkeypatch.setattr("ota_client.requests", dummy)
+    client = OtaClient(
+        {
+            "owner": "o",
+            "repo": "r",
+            "connect_timeout_sec": 1,
+            "http_timeout_sec": 2,
+        }
+    )
+    client._get("http://example.com")
+    assert dummy.timeout == (1, 2)
+


### PR DESCRIPTION
## Summary
- allow configuring connect and read timeouts for HTTP requests
- add test covering timeout propagation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb8868f20083338adfa6cd86da5543