### PR TITLE
Handle MicroPython timeout semantics

### DIFF
--- a/ota_client.py
+++ b/ota_client.py
@@ -158,7 +158,10 @@ class OtaClient:
         read_timeout = self.cfg.get("http_timeout_sec")
         timeout = None
         if connect_timeout is not None and read_timeout is not None:
-            timeout = (connect_timeout, read_timeout)
+            if MICROPYTHON:
+                timeout = max(connect_timeout, read_timeout)
+            else:
+                timeout = (connect_timeout, read_timeout)
         elif connect_timeout is not None:
             timeout = connect_timeout
         elif read_timeout is not None:

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -31,3 +31,19 @@ def test_get_uses_configured_timeouts(monkeypatch):
     client._get("http://example.com")
     assert dummy.timeout == (1, 2)
 
+
+def test_get_uses_single_timeout_on_micropython(monkeypatch):
+    dummy = DummyRequests()
+    monkeypatch.setattr("ota_client.requests", dummy)
+    monkeypatch.setattr("ota_client.MICROPYTHON", True)
+    client = OtaClient(
+        {
+            "owner": "o",
+            "repo": "r",
+            "connect_timeout_sec": 1,
+            "http_timeout_sec": 2,
+        }
+    )
+    client._get("http://example.com")
+    assert dummy.timeout == 2
+


### PR DESCRIPTION
## Summary
- For MicroPython, collapse connect and read timeouts to a single numeric value using `max()`
- Add test ensuring `_get` forwards single timeout when `MICROPYTHON` is true

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8a5b2a248333ba07dec462e21020