### PR TITLE
Clarify timeout behavior on MicroPython

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ staged before an atomic swap with rollback support.
    - `ignore` (list of strings) – paths to skip during updates.
    - `chunk` (integer) – download buffer size in bytes.
    - `connect_timeout_sec` / `http_timeout_sec` (integer) – network timeout values.
+     On MicroPython these are merged into a single effective timeout computed as
+     the larger of the two values.
    - `retries` (integer) – number of retry attempts.
    - `backoff_sec` (integer) – delay between retries in seconds.
    - `debug` (boolean) – set to `true` for verbose logging.


### PR DESCRIPTION
## Summary
- document that MicroPython merges `connect_timeout_sec` and `http_timeout_sec`
- note that the effective timeout uses the larger of the two values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb8a7e89b4833390abe2efa4a5adb0