### PR TITLE
Handle missing stream support

### DIFF
--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,51 @@
+from ota_client import OtaClient
+
+
+class ReqWithStream:
+    def __init__(self):
+        self.stream = None
+
+    def get(self, url, headers=None, stream=None, timeout=None):
+        self.stream = stream
+
+        class Resp:
+            status_code = 200
+
+            def close(self):
+                pass
+
+        return Resp()
+
+
+def test_get_passes_stream_when_supported(monkeypatch):
+    dummy = ReqWithStream()
+    monkeypatch.setattr("ota_client.requests", dummy)
+    client = OtaClient({"owner": "o", "repo": "r"})
+    client._get("http://example.com", raw=True)
+    assert dummy.stream is True
+    client._get("http://example.com", raw=False)
+    assert dummy.stream is False
+
+
+class ReqNoStream:
+    def __init__(self):
+        self.called = False
+
+    def get(self, url, headers=None, timeout=None):
+        self.called = True
+
+        class Resp:
+            status_code = 200
+
+            def close(self):
+                pass
+
+        return Resp()
+
+
+def test_get_omits_stream_when_not_supported(monkeypatch):
+    dummy = ReqNoStream()
+    monkeypatch.setattr("ota_client.requests", dummy)
+    client = OtaClient({"owner": "o", "repo": "r"})
+    client._get("http://example.com", raw=True)
+    assert dummy.called


### PR DESCRIPTION
## Summary
- only pass `stream` to `requests.get` when the active implementation supports it
- add regression tests for conditional streaming

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8b50546c8333a408bb36b4beda10