### PR TITLE
Validate GitHub owner and repo config for OTA client

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,15 @@ from ota_client import OtaClient
 
 def load_config():
     with open("ota_config.json") as f:
-        return json.load(f)
+        cfg = json.load(f)
+    placeholders = {"YOUR_GITHUB_USERNAME", "YOUR_REPO_NAME"}
+    owner = str(cfg.get("owner", "")).strip().upper()
+    repo = str(cfg.get("repo", "")).strip().upper()
+    if not owner or owner in placeholders or not repo or repo in placeholders:
+        raise ValueError(
+            "ota_config.json must define non-placeholder 'owner' and 'repo' values"
+        )
+    return cfg
 
 
 def main():

--- a/ota_client.py
+++ b/ota_client.py
@@ -110,6 +110,17 @@ class OtaClient:
         self.cfg = cfg
         self.owner = cfg.get("owner")
         self.repo = cfg.get("repo")
+        placeholders = {"YOUR_GITHUB_USERNAME", "YOUR_REPO_NAME"}
+        owner_upper = str(self.owner or "").strip().upper()
+        repo_upper = str(self.repo or "").strip().upper()
+        if not owner_upper or owner_upper in placeholders:
+            raise ValueError(
+                "Configuration 'owner' must be set to a valid GitHub username"
+            )
+        if not repo_upper or repo_upper in placeholders:
+            raise ValueError(
+                "Configuration 'repo' must be set to a valid repository name"
+            )
         self.debug = bool(cfg.get("debug"))
         self.stage_dir = STAGE_DIR
         self.backup_dir = BACKUP_DIR

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,20 @@
+import pytest
+from ota_client import OtaClient
+
+
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        {},
+        {"repo": "r"},
+        {"owner": "o"},
+        {"owner": "", "repo": "r"},
+        {"owner": "o", "repo": ""},
+        {"owner": "YOUR_GITHUB_USERNAME", "repo": "r"},
+        {"owner": "o", "repo": "YOUR_REPO_NAME"},
+    ],
+)
+
+def test_invalid_owner_repo(cfg):
+    with pytest.raises(ValueError):
+        OtaClient(cfg)


### PR DESCRIPTION
## Summary
- ensure configuration owner/repo fields are not placeholders
- reject missing owner or repo values at client start
- test invalid configuration cases

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb8b531a608333a79efc437bb3ff4c