### PR TITLE
Handle MicroPython single timeout

### DIFF
--- a/ota_client.py
+++ b/ota_client.py
@@ -193,10 +193,11 @@ class OtaClient:
         read_timeout = self.cfg.get("http_timeout_sec")
         timeout = None
         if connect_timeout is not None and read_timeout is not None:
-            if MICROPYTHON:
-                timeout = max(connect_timeout, read_timeout)
-            else:
-                timeout = (connect_timeout, read_timeout)
+            timeout = (
+                max(connect_timeout, read_timeout)
+                if MICROPYTHON
+                else (connect_timeout, read_timeout)
+            )
         elif connect_timeout is not None:
             timeout = connect_timeout
         elif read_timeout is not None:

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -45,5 +45,6 @@ def test_get_uses_single_timeout_on_micropython(monkeypatch):
         }
     )
     client._get("http://example.com")
-    assert dummy.timeout == 2
+    assert not isinstance(dummy.timeout, tuple)
+    assert dummy.timeout == max(1, 2)
 


### PR DESCRIPTION
## Summary
- ensure `_get` forwards a single numeric timeout under MicroPython by using the larger value
- expand timeout test to assert numeric timeout and no tuple when `MICROPYTHON` is set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb8c76e7148333a32fede3bc422cd2