### PR TITLE
Clarify MicroPython timeout handling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ staged before an atomic swap with rollback support.
    - `token` (string) – GitHub API token; use an empty string (`""`) for public repositories.
    - `allow` (list of strings) – whitelist of paths to update.
    - `ignore` (list of strings) – paths to skip during updates.
-   - `chunk` (integer) – download buffer size in bytes.
-   - `connect_timeout_sec` / `http_timeout_sec` (integer) – network timeout values.
-     On MicroPython these are merged into a single effective timeout computed as
-     the larger of the two values.
-   - `retries` (integer) – number of retry attempts.
-   - `backoff_sec` (integer) – delay between retries in seconds.
-   - `debug` (boolean) – set to `true` for verbose logging.
+  - `chunk` (integer) – download buffer size in bytes.
+  - `connect_timeout_sec` / `http_timeout_sec` (integer) – network timeout values.
+    On MicroPython the two fields collapse into one effective timeout equal to
+    the larger of the provided values.
+  - `retries` (integer) – number of retry attempts.
+  - `backoff_sec` (integer) – delay between retries in seconds.
+  - `debug` (boolean) – set to `true` for verbose logging.
 
    Booleans must use lowercase `true` or `false` without quotes.
 


### PR DESCRIPTION
## Summary
- Document how MicroPython merges `connect_timeout_sec` and `http_timeout_sec` into a single effective timeout using the larger value.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb8c7e099483339266241447da524f