### PR TITLE
Handle raw streaming responses in OTA client

### DIFF
--- a/ota_client.py
+++ b/ota_client.py
@@ -94,8 +94,11 @@ def git_blob_sha1_stream(total_size, reader, chunk):
 
 def http_reader(resp):
     def _yield(n):
+        source = getattr(resp, "raw", None)
+        if source is None or not hasattr(source, "read"):
+            source = resp
         while True:
-            b = resp.read(n)
+            b = source.read(n)
             if not b:
                 break
             yield b

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,5 +1,6 @@
 import os
 import hashlib
+import io
 from ota_client import OtaClient, git_blob_sha1_stream
 
 
@@ -17,6 +18,14 @@ class Resp:
         pass
 
 
+class RawResp:
+    def __init__(self, data):
+        self.raw = io.BytesIO(data)
+
+    def close(self):
+        pass
+
+
 def test_stream_and_verify(tmp_path):
     data = b"hello"
     size = len(data)
@@ -29,6 +38,23 @@ def test_stream_and_verify(tmp_path):
     client.ensure_dirs(client.stage_dir)
     client.ensure_dirs(client.backup_dir)
     client._get = lambda url, raw=False: Resp(data)
+    assert client.stream_and_verify(entry, "ref")
+    staged = tmp_path / ".stage" / "file.txt"
+    assert staged.read_bytes() == data
+
+
+def test_stream_and_verify_requests_raw(tmp_path):
+    data = b"hello"
+    size = len(data)
+    sha = hashlib.sha1(b"blob " + str(size).encode() + b"\0" + data).hexdigest()
+    entry = {"path": "file.txt", "size": size, "sha": sha, "type": "blob"}
+    cfg = {"owner": "o", "repo": "r", "chunk": 4}
+    client = OtaClient(cfg)
+    client.stage_dir = str(tmp_path / ".stage")
+    client.backup_dir = str(tmp_path / ".backup")
+    client.ensure_dirs(client.stage_dir)
+    client.ensure_dirs(client.backup_dir)
+    client._get = lambda url, raw=False: RawResp(data)
     assert client.stream_and_verify(entry, "ref")
     staged = tmp_path / ".stage" / "file.txt"
     assert staged.read_bytes() == data


### PR DESCRIPTION
## Summary
- Prefer `resp.raw.read` in `http_reader` when available to support requests-style streaming responses
- Add regression test covering raw streaming via a mock response with `.raw.read`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8cb3ff988333aaf9338b4619ddf2