### PR TITLE
Add configurable reset mode and helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,15 @@ staged before an atomic swap with rollback support.
      "http_timeout_sec": 20,
      "retries": 3,
      "backoff_sec": 3,
+     "reset_mode": "hard",
      "debug": false
    }
    ```
 
    Set `debug` to `true` to enable verbose logging for troubleshooting.
+   The `reset_mode` field controls how the device restarts after an update:
+   `hard` (default) uses `machine.reset()`, `soft` attempts `machine.soft_reset()`,
+   and `none` skips resetting.
 
    The configuration fields are:
 
@@ -84,6 +88,8 @@ staged before an atomic swap with rollback support.
     the larger of the provided values.
   - `retries` (integer) – number of retry attempts.
   - `backoff_sec` (integer) – delay between retries in seconds.
+  - `reset_mode` (string) – `hard` for a full reset (default), `soft` for a
+    soft reset when supported, or `none` to disable automatic resets.
   - `debug` (boolean) – set to `true` for verbose logging.
 
    Booleans must use lowercase `true` or `false` without quotes.

--- a/ota.py
+++ b/ota.py
@@ -46,6 +46,9 @@ else:  # pragma: no cover
         def reset(self):
             pass
 
+        def soft_reset(self):
+            pass
+
     machine = _Machine()  # type: ignore
 
 # ------------------------------------------------------------
@@ -652,6 +655,16 @@ class OTA:
             return None
 
     # --------------------------------------------------------
+    # Reset handling
+
+    def _perform_reset(self):
+        mode = self.cfg.get("reset_mode", "hard")
+        if mode == "soft" and hasattr(machine, "soft_reset"):
+            machine.soft_reset()
+        elif mode == "hard":
+            machine.reset()
+
+    # --------------------------------------------------------
     # Signed manifest path for stable release
 
     def _verify_manifest_signature(self, manifest: dict):
@@ -745,7 +758,7 @@ class OTA:
             if res is not None:
                 if res.get("updated"):
                     self._debug("Resetting device")
-                    machine.reset()
+                    self._perform_reset()
                     return True
                 print("No update required")
                 return False
@@ -767,7 +780,7 @@ class OTA:
             self.stream_and_verify_git(entry, ref_for_download)
         self.stage_and_swap(target["ref"])
         self._debug("Resetting device")
-        machine.reset()
+        self._perform_reset()
         return True
 
     # --------------------------------------------------------

--- a/ota_config.json
+++ b/ota_config.json
@@ -13,5 +13,6 @@
   "http_timeout_sec": 20,
   "retries": 3,
   "backoff_sec": 3,
+  "reset_mode": "hard",
   "debug": false
 }


### PR DESCRIPTION
## Summary
- add `reset_mode` option to configuration and documentation
- introduce `_perform_reset()` helper with optional soft reset
- use reset helper instead of direct `machine.reset()` calls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bba362d3048333be50375aaaa3ed55