### PR TITLE
Add YAML and TOML support to config loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ staged before an atomic swap with rollback support.
 ## Usage
 
 1. Copy `ota.py` and `main.py` to the device.
-2. Provide configuration in `ota_config.json` (an example is included).
-   Set ``channel`` to ``stable`` to pull the latest GitHub release or to
-   ``developer`` to use the tip of ``branch``.
+2. Provide configuration in `ota_config.json` (default), `ota_config.yaml`
+   / `ota_config.yml`, or `ota_config.toml`.  The loader inspects the file
+   extension to parse JSON, YAML or TOML.  YAML parsing requires the optional
+   [PyYAML](https://pyyaml.org/) dependency; TOML uses Python's built‑in
+   `tomllib` (3.11+).  Set ``channel`` to ``stable`` to pull the latest
+   GitHub release or to ``developer`` to use the tip of ``branch``.
 3. For manifest based updates build a release that contains an asset named
    `manifest.json`.  For manifestless mode the client derives the file list
    directly from the Git tree at the chosen ref.  Use `manifest_gen.py` on
@@ -64,6 +67,46 @@ staged before an atomic swap with rollback support.
      "reset_mode": "hard",
      "debug": false
    }
+   ```
+
+   Equivalent YAML:
+
+   ```yaml
+   owner: YOUR_GITHUB_USERNAME
+   repo: ota
+   ssid: YOUR_WIFI_SSID
+   password: YOUR_WIFI_PASSWORD
+   channel: developer
+   branch: main
+   allow: [README.md]
+   ignore: []
+   chunk: 512
+   connect_timeout_sec: 20
+   http_timeout_sec: 20
+   retries: 3
+   backoff_sec: 3
+   reset_mode: hard
+   debug: false
+   ```
+
+   Equivalent TOML:
+
+   ```toml
+   owner = "YOUR_GITHUB_USERNAME"
+   repo = "ota"
+   ssid = "YOUR_WIFI_SSID"
+   password = "YOUR_WIFI_PASSWORD"
+   channel = "developer"
+   branch = "main"
+   allow = ["README.md"]
+   ignore = []
+   chunk = 512
+   connect_timeout_sec = 20
+   http_timeout_sec = 20
+   retries = 3
+   backoff_sec = 3
+   reset_mode = "hard"
+   debug = false
    ```
 
    Set `debug` to `true` to enable verbose logging for troubleshooting.

--- a/integration_test.py
+++ b/integration_test.py
@@ -1,12 +1,11 @@
 """Toggle update channel and perform a dry run against the configured repo."""
 
-import json
 from ota import OTA
+from main import load_config
 
 
 def run(channel):
-    with open("ota_config.json") as f:
-        cfg = json.load(f)
+    cfg = load_config()
     cfg["channel"] = channel
     client = OTA(cfg)
     # This is a dry run – in real usage ``update_if_available`` would

--- a/main.py
+++ b/main.py
@@ -1,18 +1,39 @@
 """Example entry point for the ``OTA`` updater."""
 
 import json
+from pathlib import Path
+
 from ota import OTA
 
+try:  # Python 3.11+
+    import tomllib  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - earlier versions
+    tomllib = None
 
-def load_config():
-    with open("ota_config.json") as f:
-        cfg = json.load(f)
+
+def load_config(config_path: str = "ota_config.json"):
+    """Load configuration from JSON, YAML or TOML based on extension."""
+    path = Path(config_path)
+    text = path.read_text()
+    ext = path.suffix.lower()
+    if ext in (".yaml", ".yml"):
+        try:
+            import yaml
+        except Exception as exc:  # pragma: no cover - missing dependency
+            raise RuntimeError("PyYAML is required for YAML config files") from exc
+        cfg = yaml.safe_load(text) or {}
+    elif ext == ".toml":
+        if tomllib is None:
+            raise RuntimeError("TOML config requires Python 3.11 or the tomllib module")
+        cfg = tomllib.loads(text)
+    else:
+        cfg = json.loads(text)
     placeholders = {"YOUR_GITHUB_USERNAME", "YOUR_REPO_NAME"}
     owner = str(cfg.get("owner", "")).strip().upper()
     repo = str(cfg.get("repo", "")).strip().upper()
     if not owner or owner in placeholders or not repo or repo in placeholders:
         raise ValueError(
-            "ota_config.json must define non-placeholder 'owner' and 'repo' values"
+            f"{path.name} must define non-placeholder 'owner' and 'repo' values"
         )
     return cfg
 

--- a/tests/test_load_config.py
+++ b/tests/test_load_config.py
@@ -1,0 +1,22 @@
+import pytest
+
+import main
+
+
+def test_load_config_formats(tmp_path):
+    json_cfg = '{"owner":"O","repo":"R"}'
+    toml_cfg = 'owner = "O"\nrepo = "R"\n'
+
+    json_path = tmp_path / "cfg.json"
+    toml_path = tmp_path / "cfg.toml"
+
+    json_path.write_text(json_cfg)
+    toml_path.write_text(toml_cfg)
+
+    assert main.load_config(str(json_path))["owner"] == "O"
+    assert main.load_config(str(toml_path))["repo"] == "R"
+
+    yaml_mod = pytest.importorskip("yaml")
+    yaml_path = tmp_path / "cfg.yaml"
+    yaml_path.write_text("owner: O\nrepo: R\n")
+    assert main.load_config(str(yaml_path))["owner"] == "O"


### PR DESCRIPTION
## Summary
- allow `load_config` to parse YAML and TOML files based on extension
- update integration test and docs for new config formats
- cover loader with a unit test

## Testing
- `pytest`
- `python integration_test.py` *(fails: ota_config.json must define non-placeholder 'owner' and 'repo' values)*

------
https://chatgpt.com/codex/tasks/task_e_68bba50c0cb08333ab26b9219e325a59