### PR TITLE
feat: add 'none' reset option and centralize reset logging

### DIFF
--- a/ota.py
+++ b/ota.py
@@ -659,9 +659,14 @@ class OTA:
 
     def _perform_reset(self):
         mode = self.cfg.get("reset_mode", "hard")
+        if mode == "none":
+            self._debug("Not resetting device")
+            return
         if mode == "soft" and hasattr(machine, "soft_reset"):
+            self._debug("Performing soft reset...")
             machine.soft_reset()
-        elif mode == "hard":
+        else:
+            self._debug("Performing hard reset...")
             machine.reset()
 
     # --------------------------------------------------------
@@ -757,7 +762,6 @@ class OTA:
             res = self._stable_with_manifest(target["release_json"], target["ref"])
             if res is not None:
                 if res.get("updated"):
-                    self._debug("Resetting device")
                     self._perform_reset()
                     return True
                 print("No update required")
@@ -779,7 +783,6 @@ class OTA:
         for entry in candidates:
             self.stream_and_verify_git(entry, ref_for_download)
         self.stage_and_swap(target["ref"])
-        self._debug("Resetting device")
         self._perform_reset()
         return True
 

--- a/ota_config.json
+++ b/ota_config.json
@@ -14,5 +14,6 @@
   "retries": 3,
   "backoff_sec": 3,
   "reset_mode": "hard",
+  "_reset_mode_comment": "hard for machine.reset(), soft for machine.soft_reset(), none to skip",
   "debug": false
 }


### PR DESCRIPTION
## Summary
- allow disabling resets and include all reset logging within `_perform_reset`
- drop reset debug calls from `update_if_available`
- document `reset_mode` options in `ota_config.json`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bba515d630833382b1e5f97af01c90