### PR TITLE
docs: acknowledge original fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MicroPython OTA Updater
 
+This project was originally forked from [kevinmcaleer/ota](https://github.com/kevinmcaleer/ota) by Kevin McAleer.
+
 Robust over‑the‑air (OTA) update system for MicroPython devices.  The updater
 can pull application bundles either from the latest GitHub release
 (``stable`` channel) or from the tip of a development branch (``developer``


### PR DESCRIPTION
## Summary
- credit Kevin McAleer and his [kevinmcaleer/ota](https://github.com/kevinmcaleer/ota) repository as the original fork source in README

## Testing
- `python integration_test.py` *(fails: ota_config.json must define non placeholder 'owner' and 'repo' values)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbb03257008333ad13eda77213696d