### PR TITLE
Persist OTA commit information

### DIFF
--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -18,11 +18,13 @@ def test_staging_and_swap(tmp_path):
             f.write('new')
         ensure_dirs(updater.stage)
         ensure_dirs(updater.backup)
-        updater.stage_and_swap('v1')
+        updater.stage_and_swap('v1', 'deadbeef')
         # Verify update
         with open('app.py') as f:
             assert f.read() == 'new'
         with open('version.json') as f:
-            assert json.load(f)['ref'] == 'v1'
+            data = json.load(f)
+            assert data['ref'] == 'v1'
+            assert data['commit'] == 'deadbeef'
     finally:
         os.chdir(cwd)

--- a/tests/test_swap.py
+++ b/tests/test_swap.py
@@ -21,10 +21,10 @@ def test_stage_and_swap(tmp_path, monkeypatch):
     _write(tmp_path / "app.txt", b"old")
     # staged replacement
     _write(tmp_path / "stage" / "app.txt", b"new")
-    c.stage_and_swap("ref123")
+    c.stage_and_swap("ref123", "c1")
     assert (tmp_path / "app.txt").read_bytes() == b"new"
     with open(tmp_path / "version.json") as f:
-        assert f.read().strip() == '{"ref": "ref123"}'
+        assert f.read().strip() == '{"ref": "ref123", "commit": "c1"}'
 
 
 def test_stage_and_swap_rollback(tmp_path, monkeypatch):
@@ -48,7 +48,7 @@ def test_stage_and_swap_rollback(tmp_path, monkeypatch):
 
     monkeypatch.setattr(os, "rename", failing)
     with pytest.raises(OSError):
-        c.stage_and_swap("ref")
+        c.stage_and_swap("ref", "commit")
     # original file restored
     assert (tmp_path / "app.txt").read_bytes() == b"orig"
     assert not (tmp_path / "version.json").exists()


### PR DESCRIPTION
## Summary
- record both ref and commit when applying updates
- skip downloads if stored commit matches latest
- update tests for new OTA state format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbb2ddc8bc8333829d70f5d911edba