### PR TITLE
chore: add pyproject for packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 __pycache__
 *.pyc
 WIFI_CONFIG.py
+build/
+dist/
+*.egg-info/
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "micropython-ota-updater"
+version = "0.1.0"
+description = "Robust over-the-air update system for MicroPython devices"
+readme = "README.md"
+license = {file = "LICENSE"}
+authors = [{name = "AJ McArdle"}]
+requires-python = ">=3.8"
+
+[project.urls]
+Homepage = "https://github.com/ajmcardle/ota"
+
+[tool.setuptools]
+py-modules = ["ota", "manifest_gen", "main"]


### PR DESCRIPTION
## Summary
- add pyproject.toml so `python -m build` can package the modules
- ignore build artifacts

## Testing
- `pytest`
- `python -m build` *(fails: No module named build, pip install blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc1120d588333afaa6b9e7538414f