### PR TITLE
Log release version when updating stable manifest

### DIFF
--- a/ota.py
+++ b/ota.py
@@ -856,6 +856,8 @@ class OTA:
         self._verify_manifest_signature(manifest)
         current = self._read_state()
         version = manifest.get("version", tag)
+        if self.cfg.get("channel", "stable") == "stable":
+            self._debug("Release version:", version)
         if (
             not self.cfg.get("force")
             and current


### PR DESCRIPTION
## Summary
- Debug log the resolved release version during stable updates for easier verification

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbc3faedbc8333aac2a14fe00104f8