### PR TITLE
feat: shorten debug commit hashes

### DIFF
--- a/ota.py
+++ b/ota.py
@@ -280,6 +280,24 @@ class OTA:
         if self.cfg.get("debug"):
             print("[OTA]", *args)
 
+    def _format_version(self, state: dict) -> str:
+        """Format version info for debug output.
+
+        Shortens the commit hash and combines it with the ref when available.
+        """
+        if not state:
+            return ""
+        ref = state.get("ref")
+        commit = state.get("commit")
+        short = commit[:7] if commit else None
+        if ref and short:
+            return f"{ref} #{short}"
+        if ref:
+            return ref
+        if short:
+            return f"#{short}"
+        return ""
+
     # --------------------------------------------------------
     # Resource checks
 
@@ -422,7 +440,7 @@ class OTA:
         if not self.cfg.get("debug"):
             return
         state = self._read_state()
-        self._debug("Installed version:", state)
+        self._debug("Installed version:", self._format_version(state))
 
         cpu = self._cpu_mhz()
         if cpu is not None:
@@ -903,10 +921,10 @@ class OTA:
             return False
         self._debug_resources()
         target = self.resolve_target()
-        self._debug("Resolving target:", target)
+        self._debug("Resolving target:", target["mode"], self._format_version(target))
         state = self._read_state()
-        self._debug("Installed version:", state)
-        self._debug("Repo version:", {"ref": target["ref"], "commit": target["commit"]})
+        self._debug("Installed version:", self._format_version(state))
+        self._debug("Repo version:", self._format_version(target))
         if target["mode"] == "tag":
             res = self._stable_with_manifest(target["release_json"], target["ref"], target["commit"])
             if res is not None:

--- a/tests/test_format_version.py
+++ b/tests/test_format_version.py
@@ -1,0 +1,32 @@
+from ota import OTA
+
+
+def test_format_version():
+    ota = OTA({})
+    assert ota._format_version({'ref': 'v1.0', 'commit': 'abcdef1234567890'}) == 'v1.0 #abcdef1'
+    assert ota._format_version({'ref': 'v1.0'}) == 'v1.0'
+    assert ota._format_version({'commit': 'abcdef1234567890'}) == '#abcdef1'
+    assert ota._format_version({}) == ''
+
+
+def test_update_if_available_formats_debug(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    cfg = {'owner': 'o', 'repo': 'r', 'debug': True}
+    ota = OTA(cfg)
+    monkeypatch.setattr(ota, 'connect', lambda: None)
+    monkeypatch.setattr(ota, '_check_basic_resources', lambda: True)
+    monkeypatch.setattr(ota, '_debug_resources', lambda: None)
+    target = {'mode': 'branch', 'ref': 'main', 'commit': '123456789abcdef'}
+    state = {'ref': 'v1', 'commit': '9876543210abcdef'}
+    monkeypatch.setattr(ota, 'resolve_target', lambda: target)
+    monkeypatch.setattr(ota, '_read_state', lambda: state)
+    monkeypatch.setattr(ota, 'fetch_tree', lambda commit: [])
+    monkeypatch.setattr(ota, 'iter_candidates', lambda tree: iter([]))
+    monkeypatch.setattr(ota, '_check_storage', lambda required: True)
+    monkeypatch.setattr(ota, 'stage_and_swap', lambda ref, commit, **kwargs: None)
+    monkeypatch.setattr(ota, '_perform_reset', lambda: None)
+    assert ota.update_if_available()
+    out = capsys.readouterr().out.splitlines()
+    assert "[OTA] Resolving target: branch main #1234567" in out
+    assert "[OTA] Installed version: v1 #9876543" in out
+    assert "[OTA] Repo version: main #1234567" in out


### PR DESCRIPTION
## Summary
- format version info with short commit hashes
- clean up debug output to use formatted versions
- add tests for version formatting and debug output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbc7b198ac833380d035fd178b87b1