### PR TITLE
Add path normalization to prevent traversal in OTA paths

### DIFF
--- a/tests/test_path_sanity.py
+++ b/tests/test_path_sanity.py
@@ -1,0 +1,63 @@
+import pytest
+from ota import OTA, OTAError
+
+
+class Resp:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    return OTA({'owner': 'o', 'repo': 'r'})
+
+
+@pytest.mark.parametrize('path', [
+    '../bad',
+    '/bad',
+    'dir/../bad',
+    'dir/./bad',
+    'dir//bad',
+])
+def test_stage_path_rejects(client, path):
+    with pytest.raises(OTAError):
+        client._stage_path(path)
+
+
+@pytest.mark.parametrize('path', [
+    '../bad',
+    '/bad',
+    'dir/../bad',
+    'dir/./bad',
+    'dir//bad',
+])
+def test_backup_path_rejects(client, path):
+    with pytest.raises(OTAError):
+        client._backup_path(path)
+
+
+@pytest.mark.parametrize('path', [
+    '../bad',
+    '/bad',
+    'dir/../bad',
+    'dir/./bad',
+    'dir//bad',
+])
+def test_manifest_file_rejects(client, path, monkeypatch):
+    manifest = {
+        'version': 'v1',
+        'files': [{'path': path}],
+    }
+    rel_json = {
+        'assets': [{'name': 'manifest.json', 'browser_download_url': 'http://example/manifest.json'}]
+    }
+    monkeypatch.setattr(client, '_get', lambda url, raw=True: Resp(manifest))
+    monkeypatch.setattr(client, '_verify_manifest_signature', lambda m: None)
+    monkeypatch.setattr(client, '_read_state', lambda: None)
+    with pytest.raises(OTAError):
+        client._stable_with_manifest(rel_json, 'v1', 'abc')


### PR DESCRIPTION
## Summary
- Add `_normalize_path` to reject absolute and traversal paths
- Use `_normalize_path` in `_stage_path`, `_backup_path`, and manifest processing
- Test path rejection for staging, backups, and manifest files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbd027ec708333850469c679497f2b