### PR TITLE
Normalize OTA allow/ignore path handling

### DIFF
--- a/tests/test_path_filtering.py
+++ b/tests/test_path_filtering.py
@@ -13,8 +13,15 @@ class Resp:
 
 def test_is_permitted_filters(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
-    cfg = {'owner': 'o', 'repo': 'r', 'allow': ['allowed', 'exact.txt'], 'ignore': ['allowed/skip']}
+    cfg = {
+        'owner': 'o',
+        'repo': 'r',
+        'allow': ['/allowed/', '/exact.txt'],
+        'ignore': ['/allowed/skip/'],
+    }
     client = OTA(cfg)
+    assert client._allow == ('allowed', 'exact.txt')
+    assert client._ignore == ('allowed/skip',)
     assert client._is_permitted('exact.txt')
     assert client._is_permitted('allowed/file.txt')
     assert not client._is_permitted('other/file.txt')


### PR DESCRIPTION
## Summary
- normalize allow/ignore lists on initialization
- use cached path prefixes in `_is_permitted`
- test path filter initialization with leading/trailing slashes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbd10b7d1c8333b4a6fe56b1a3eb00