### PR TITLE
fix: Correct README issues from PR #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,8 @@ Error: no space left on device
   print(f"Free: {free_kb} KB")
   ```
 - Delete old files/logs
-- Exclude large files: `"ignore": ["data/", "*.bmp"]`
+- Exclude directories: `"ignore": ["data/", "images/"]`
+- Note: Only exact paths or directory prefixes supported (no wildcards like `*.bmp`)
 
 ### Debug Mode
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ print('README.md' in os.listdir('/'))  # Should print: True
 
 ### Next Steps
 - See [Usage](#usage) for production deployment with manifest-based releases
-- Enable [Security](#security-best-practices) with tokens and signed manifests
+- Enable [Security](#security-notes) with tokens and signed manifests
 - Configure [Headless Operation](#headless-operation) for remote devices
 - Set up [Delta Updates](#delta-updates) to reduce bandwidth by 60-95%
 


### PR DESCRIPTION
## Summary

Fixes two issues in the README introduced by PR #56:

1. **Broken anchor link**: Quick Start "Next Steps" referenced `#security-best-practices` but the actual section is `#security-notes`
2. **Invalid filter pattern**: Troubleshooting suggested `*.bmp` wildcard pattern, but the filter implementation only supports exact paths and directory prefixes

## Changes

### Fix 1: Broken Security Link
**Before:** `[Security](#security-best-practices)`
**After:** `[Security](#security-notes)`

Corrects the anchor to match the actual section heading at line 319.

### Fix 2: Wildcard Pattern Documentation
**Before:**
```json
"ignore": ["data/", "*.bmp"]
```

**After:**
```json
"ignore": ["data/", "images/"]
```

Plus added note: "Only exact paths or directory prefixes supported (no wildcards like `*.bmp`)"

## Root Cause

The filter implementation in ota.py:399-411 uses:
- Exact path matching: `path in self._ignore`
- Prefix matching: `path.startswith(p)` for entries ending with `/`

It does NOT support glob patterns like `*.bmp`, so suggesting them in Troubleshooting would mislead users trying to resolve "no space left on device" errors.

## Test Plan

- [x] Verified `#security-notes` anchor exists (line 319)
- [x] Confirmed all other Next Steps links are valid
- [x] Validated against ota.py filter implementation (lines 399-411)
- [x] Checked no other wildcard patterns suggested in README

## References

- Addresses Codex review feedback on PR #56
- Filter implementation: ota.py lines 352-360 (initialization), 399-411 (matching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)